### PR TITLE
Update ADR statuses

### DIFF
--- a/PCF-ADR-0000-template.md
+++ b/PCF-ADR-0000-template.md
@@ -3,16 +3,16 @@
 <!-- copy and paste this template to start authoring your own ADR -->
 <!-- remove this comment block too -->
 
-|                |                          |
-| -------------- | ------------------------ |
-| Date           | insert date              |
-| Scope          |                          |
-| Status         | Draft                    |
-| Authors        | [name](@github-username) |
-| Supersedes     | N/A                      |
-| Superseded by: | N/A                      |
-| Issues         |                          |
-| Other docs:    | none                     |
+|                |                                                                                  |
+| -------------- | -------------------------------------------------------------------------------- |
+| Date           | insert date                                                                      |
+| Scope          |                                                                                  |
+| Status         | provisional\|implementable\|implemented\|deferred\|rejected\|withdrawn\|replaced |
+| Authors        | [name](@github-username)                                                         |
+| Supersedes     | N/A                                                                              |
+| Superseded by: | N/A                                                                              |
+| Issues         |                                                                                  |
+| Other docs:    | none                                                                             |
 
 ## What
 
@@ -52,12 +52,12 @@ Optional section. Talk about any risks here.
 
 ## Stakeholder Impacts
 
-| Group                         | Key Contacts     | Date       | Impacted? |
-| ----------------------------- | ---------------- | ---------- | --------- |
-| CodeFlare SDK                 | key contact name | date       | ?         |
-| MCAD                          | key contact name | date       | ?         |
-| InstaScale                    | key contact name | date       | ?         |
-| CodeFlare Operator            | key contact name | date       | ?         |
+| Group              | Key Contacts     | Date | Impacted? |
+| ------------------ | ---------------- | ---- | --------- |
+| CodeFlare SDK      | key contact name | date | ?         |
+| MCAD               | key contact name | date | ?         |
+| InstaScale         | key contact name | date | ?         |
+| CodeFlare Operator | key contact name | date | ?         |
 
 ## References
 

--- a/PCF-ADR-0001-use-architecture-decision-records-for-project-codeflare.md
+++ b/PCF-ADR-0001-use-architecture-decision-records-for-project-codeflare.md
@@ -1,15 +1,15 @@
 # Use Architecture Decision Records for Project CodeFlare
 
-|                |                          |
-| -------------- | ------------------------ |
-| Date           | insert date              |
-| Scope          |                          |
-| Status         | Draft                    |
+|                |                                |
+| -------------- | ------------------------------ |
+| Date           | insert date                    |
+| Scope          |                                |
+| Status         | implemented                    |
 | Authors        | [Anish Asthana](@anishasthana) |
-| Supersedes     | N/A                      |
-| Superseded by: | N/A                      |
-| Issues         |                          |
-| Other docs:    | none                     |
+| Supersedes     | N/A                            |
+| Superseded by: | N/A                            |
+| Issues         |                                |
+| Other docs:    | none                           |
 
 ## Project CodeFlare Architecture Decision Records
 
@@ -39,13 +39,13 @@ ADRs will require at least two approvals in addition to being open for at least 
 
 ## Reviews
 
-| Reviewed by                   | Date       | Notes |
-| ----------------------------- | ---------  | ------|
+| Reviewed by        | Date       | Notes    |
+| ------------------ | ---------- | -------- |
 | Abhishek Malvankar | 04-18-2023 | Approved |
-| Alex Corvin | 04-18-2023 | Approved |
-| Ashish Kamra | 04-19-2023 | Approved |
+| Alex Corvin        | 04-18-2023 | Approved |
+| Ashish Kamra       | 04-19-2023 | Approved |
 | Kevin Postlethwait | 04-18-2023 | Approved |
-| Mustafa Eyceoz | 04-18-2023 | Approved |
+| Mustafa Eyceoz     | 04-18-2023 | Approved |
 
 ## References
 

--- a/PCF-ADR-0002-release-story-and-branch-maintenance.md
+++ b/PCF-ADR-0002-release-story-and-branch-maintenance.md
@@ -1,15 +1,15 @@
 # ADR 0002: Use GitHub Flow for Branching Strategy
 
-|                |                          |
-| -------------- | ------------------------ |
-| Date           | 4/19/2023                |
-| Scope          |                          |
-| Status         | Draft                    |
-| Authors        | [Kevin](@KPostOffice)    |
-| Supersedes     | N/A                      |
-| Superseded by: | N/A                      |
-| Issues         |                          |
-| Other docs:    | none                     |
+|                |                       |
+| -------------- | --------------------- |
+| Date           | 4/19/2023             |
+| Scope          |                       |
+| Status         | implemented           |
+| Authors        | [Kevin](@KPostOffice) |
+| Supersedes     | N/A                   |
+| Superseded by: | N/A                   |
+| Issues         |                       |
+| Other docs:    | none                  |
 
 ## What
 
@@ -168,12 +168,12 @@ branch is always in a deployable state.
 
 ## Stakeholder Impacts
 
-| Group                         | Key Contacts       | Date       | Impacted? |
-| ----------------------------- | ------------------ | ---------- | --------- |
-| CodeFlare SDK                 | Mustafa Eyceoz     | 4/19/2023  | yes       |
-| MCAD                          | Abhishek Malvankar | 4/19/2023  | yes       |
-| InstaScale                    | Abhishek Malvankar | 4/19/2023  | yes       |
-| CodeFlare Operator            | Anish Asthana      | 4/19/2023  | yes       |
+| Group              | Key Contacts       | Date      | Impacted? |
+| ------------------ | ------------------ | --------- | --------- |
+| CodeFlare SDK      | Mustafa Eyceoz     | 4/19/2023 | yes       |
+| MCAD               | Abhishek Malvankar | 4/19/2023 | yes       |
+| InstaScale         | Abhishek Malvankar | 4/19/2023 | yes       |
+| CodeFlare Operator | Anish Asthana      | 4/19/2023 | yes       |
 
 ## References
 
@@ -183,7 +183,7 @@ branch is always in a deployable state.
 
 ## Reviews
 
-| Reviewed by                   | Date       | Notes |
-| ----------------------------- | ---------  | ------|
-| Anish Asthana                 | 4/21       |       |
-| Alex Corvin                   | 4/20       |       |
+| Reviewed by   | Date | Notes |
+| ------------- | ---- | ----- |
+| Anish Asthana | 4/21 |       |
+| Alex Corvin   | 4/20 |       |

--- a/PCF-ADR-0003-codeflare-release-process.md
+++ b/PCF-ADR-0003-codeflare-release-process.md
@@ -1,15 +1,15 @@
 # Standardized release process for Project CodeFlare
 
-|                |                          |
-| -------------- | ------------------------ |
-| Date           | 04/28/2023               |
-| Scope          |                          |
-| Status         | Proposed                    |
+|                |                                                              |
+| -------------- | ------------------------------------------------------------ |
+| Date           | 04/28/2023                                                   |
+| Scope          |                                                              |
+| Status         | implemented                                                  |
 | Authors        | [Anish Asthana](@anishasthana) [Mustafa Eyceoz](@Maxusmusti) |
-| Supersedes     | N/A                      |
-| Superseded by: | N/A                      |
-| Issues         |                          |
-| Other docs:    | PCF-ADR-002              |
+| Supersedes     | N/A                                                          |
+| Superseded by: | N/A                                                          |
+| Issues         |                                                              |
+| Other docs:    | PCF-ADR-002                                                  |
 
 ## What
 
@@ -111,12 +111,12 @@ We didn't consider any other alternatives
 
 ## Stakeholder Impacts
 
-| Group                         | Key Contacts       | Date       | Impacted? |
-| ----------------------------- | ------------------ | ---------- | --------- |
-| CodeFlare SDK                 | Mustafa Eyceoz     | 04/28/2023  | yes       |
-| MCAD                          | Abhishek Malvankar | 04/28/2023  | yes       |
-| InstaScale                    | Abhishek Malvankar | 04/28/2023  | yes       |
-| CodeFlare Operator            | Anish Asthana      | 04/28/2023  | yes       |
+| Group              | Key Contacts       | Date       | Impacted? |
+| ------------------ | ------------------ | ---------- | --------- |
+| CodeFlare SDK      | Mustafa Eyceoz     | 04/28/2023 | yes       |
+| MCAD               | Abhishek Malvankar | 04/28/2023 | yes       |
+| InstaScale         | Abhishek Malvankar | 04/28/2023 | yes       |
+| CodeFlare Operator | Anish Asthana      | 04/28/2023 | yes       |
 
 ## Reviews
 

--- a/PCF-ADR-0004-codeflare-test-strategy.md
+++ b/PCF-ADR-0004-codeflare-test-strategy.md
@@ -1,15 +1,15 @@
 # Define testing strategy for Project CodeFlare
 
-|                |                          |
-| -------------- | ------------------------ |
-| Date           | 06/14/2023               |
-| Scope          |                          |
-| Status         | Proposed                 |
-| Authors        | [Karel Suta](@sutaakar), [Antonin Stefanutti](@astefanutti)  |
-| Supersedes     | N/A                      |
-| Superseded by: | N/A                      |
-| Issues         |                          |
-| Other docs:    | [PCF-ADR-0003](https://github.com/project-codeflare/adr/blob/main/PCF-ADR-0003-codeflare-release-process.md)                      |
+|                |                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------ |
+| Date           | 06/14/2023                                                                                                   |
+| Scope          |                                                                                                              |
+| Status         | implemented                                                                                                  |
+| Authors        | [Karel Suta](@sutaakar), [Antonin Stefanutti](@astefanutti)                                                  |
+| Supersedes     | N/A                                                                                                          |
+| Superseded by: | N/A                                                                                                          |
+| Issues         |                                                                                                              |
+| Other docs:    | [PCF-ADR-0003](https://github.com/project-codeflare/adr/blob/main/PCF-ADR-0003-codeflare-release-process.md) |
 
 ## What
 
@@ -69,13 +69,13 @@ Release build check:
 
 #### Testing levels and Type of testing:
 
-| Test type/development cycle  | Feature developer | PR automated checks  | PR review by reviewer | Nightly automated checks  | Release automated checks |
-| ---------------------------- | ----------------- | -------------------- | --------------------- | ------------------------- | ------------------------ |
-| Manual testing               | Yes               | No                   | Yes                   | No                        | No                       |
-| Unit testing                 | Yes               | Yes                  | No                    | Yes                       | Yes                      |
-| End to end testing           | Yes               | Yes                  | No                    | Yes                       | Yes                      |
-| Integration testing          | Optional          | Yes                  | No                    | Yes                       | Yes                      |
-| Upgrade testing              | Optional          | Yes                  | No                    | Yes                       | Yes                      |
+| Test type/development cycle | Feature developer | PR automated checks | PR review by reviewer | Nightly automated checks | Release automated checks |
+| --------------------------- | ----------------- | ------------------- | --------------------- | ------------------------ | ------------------------ |
+| Manual testing              | Yes               | No                  | Yes                   | No                       | No                       |
+| Unit testing                | Yes               | Yes                 | No                    | Yes                      | Yes                      |
+| End to end testing          | Yes               | Yes                 | No                    | Yes                      | Yes                      |
+| Integration testing         | Optional          | Yes                 | No                    | Yes                      | Yes                      |
+| Upgrade testing             | Optional          | Yes                 | No                    | Yes                      | Yes                      |
 
 Glossary:
 
@@ -254,12 +254,12 @@ We didn't consider any other alternatives
 
 ## Stakeholder Impacts
 
-| Group                         | Key Contacts       | Date       | Impacted? |
-| ----------------------------- | ------------------ | ---------- | --------- |
-| CodeFlare SDK                 | Mustafa Eyceoz     |            | yes       |
-| MCAD                          | Abhishek Malvankar |            | yes       |
-| InstaScale                    | Abhishek Malvankar |            | yes       |
-| CodeFlare Operator            | Anish Asthana      |            | yes       |
+| Group              | Key Contacts       | Date | Impacted? |
+| ------------------ | ------------------ | ---- | --------- |
+| CodeFlare SDK      | Mustafa Eyceoz     |      | yes       |
+| MCAD               | Abhishek Malvankar |      | yes       |
+| InstaScale         | Abhishek Malvankar |      | yes       |
+| CodeFlare Operator | Anish Asthana      |      | yes       |
 
 ## Reviews
 

--- a/PCF-ADR-0005-mcad-api-groups-migration.md
+++ b/PCF-ADR-0005-mcad-api-groups-migration.md
@@ -1,13 +1,13 @@
 # MCAD API Groups Migration Plan
 
-|                |                          |
-| -------------- | ------------------------ |
-| Date           | 07/31/2023               |
-| Scope          |                          |
-| Status         | Proposed                 |
-| Authors        | [Antonin Stefanutti](@astefanutti) |
-| Supersedes     | N/A                      |
-| Superseded by: | N/A                      |
+|                |                                                                              |
+| -------------- | ---------------------------------------------------------------------------- |
+| Date           | 07/31/2023                                                                   |
+| Scope          |                                                                              |
+| Status         | implementable                                                                |
+| Authors        | [Antonin Stefanutti](@astefanutti)                                           |
+| Supersedes     | N/A                                                                          |
+| Superseded by: | N/A                                                                          |
 | Issues         | https://github.com/project-codeflare/multi-cluster-app-dispatcher/issues/352 |
 
 ## What
@@ -70,13 +70,13 @@ Duplicated code would have to live in the MCAD codebase, for a potentially unbou
 
 ## Stakeholder Impacts
 
-| Group                         | Key Contacts       | Date       | Impacted? |
-| ----------------------------- | ------------------ | ---------- | --------- |
-| CodeFlare SDK                 | Mustafa Eyceoz     |            | yes       |
-| MCAD                          | Abhishek Malvankar |            | yes       |
-| InstaScale                    | Abhishek Malvankar |            | yes       |
-| KubeRay                       | Laurentiu Bradin   |            | Doc only ATM, maybe Kuberay API server |
-| CodeFlare Operator            | Anish Asthana      |            | yes       |
+| Group              | Key Contacts       | Date | Impacted?                              |
+| ------------------ | ------------------ | ---- | -------------------------------------- |
+| CodeFlare SDK      | Mustafa Eyceoz     |      | yes                                    |
+| MCAD               | Abhishek Malvankar |      | yes                                    |
+| InstaScale         | Abhishek Malvankar |      | yes                                    |
+| KubeRay            | Laurentiu Bradin   |      | Doc only ATM, maybe Kuberay API server |
+| CodeFlare Operator | Anish Asthana      |      | yes                                    |
 
 ## Reviews
 

--- a/PCF-ADR-0006-issue-template.md
+++ b/PCF-ADR-0006-issue-template.md
@@ -1,15 +1,15 @@
 # Project CodeFlare - Issue Template
 
-|                |                          |
-| -------------- | ------------------------ |
-| Date           | 8/11/2023                |
-| Scope          |                          |
-| Status         | Proposed                 |
-| Authors        | [Fiona Waters](@Fiona-Waters)   |
-| Supersedes     | N/A                      |
-| Superseded by: | N/A                      |
-| Issues         | https://github.com/project-codeflare/.github/issues/8    |
-| Other docs:    | https://github.com/project-codeflare/.github/pull/14     |
+|                |                                                       |
+| -------------- | ----------------------------------------------------- |
+| Date           | 8/11/2023                                             |
+| Scope          |                                                       |
+| Status         | implemented                                           |
+| Authors        | [Fiona Waters](@Fiona-Waters)                         |
+| Supersedes     | N/A                                                   |
+| Superseded by: | N/A                                                   |
+| Issues         | https://github.com/project-codeflare/.github/issues/8 |
+| Other docs:    | https://github.com/project-codeflare/.github/pull/14  |
 
 ## What
 Currently when creating github issues for repositories within Project Codeflare we do not use any templates. The aim of this ADR is to propose adding a defined selection of templates that will allow team members to include all relevant information when creating an issue which will allow others to effectively pick it up and complete it.
@@ -123,16 +123,16 @@ We have not currently considered any alternatives.
 
 ## Stakeholder Impacts
 
-| Group                         | Key Contacts       | Date       | Impacted? |
-| ----------------------------- | ----------------   | ---------- | --------- |
-| CodeFlare SDK                 | Mustafa Eyceoz     | date       | Yes       |
-| MCAD                          | Abhishek Malvankar | date       | Yes       |
-| InstaScale                    | Abhishek Malvankar | date       | Yes       |
-| CodeFlare Operator            | Anish Asthana      | date       | Yes       |
+| Group              | Key Contacts       | Date | Impacted? |
+| ------------------ | ------------------ | ---- | --------- |
+| CodeFlare SDK      | Mustafa Eyceoz     | date | Yes       |
+| MCAD               | Abhishek Malvankar | date | Yes       |
+| InstaScale         | Abhishek Malvankar | date | Yes       |
+| CodeFlare Operator | Anish Asthana      | date | Yes       |
 
 ## References
 
-* https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository 
+* https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
 
 ## Reviews
 

--- a/PCF-ADR-0007-operator-redesign.md
+++ b/PCF-ADR-0007-operator-redesign.md
@@ -1,13 +1,13 @@
 # CodeFlare Operator Redesign
 
-|                |                          |
-| -------------- | ------------------------ |
-| Date           | 08/28/2023               |
-| Scope          |                          |
-| Status         | Proposed                 |
-| Authors        | [Antonin Stefanutti](@astefanutti) |
-| Supersedes     | N/A                      |
-| Superseded by: | N/A                      |
+|                |                                                                    |
+| -------------- | ------------------------------------------------------------------ |
+| Date           | 08/28/2023                                                         |
+| Scope          |                                                                    |
+| Status         | implementable                                                      |
+| Authors        | [Antonin Stefanutti](@astefanutti)                                 |
+| Supersedes     | N/A                                                                |
+| Superseded by: | N/A                                                                |
 | Issues         | https://github.com/project-codeflare/codeflare-operator/issues/153 |
 
 ## What
@@ -188,12 +188,12 @@ While this would follow Operator SDK best practices, this would not provide the 
 
 ## Stakeholder Impacts
 
-| Group                         | Key Contacts                           | Date       | Impacted? |
-| ----------------------------- | -------------------------------------- | ---------- | --------- |
-| CodeFlare SDK                 | Mustafa Eyceoz, Dimitri Saridakis      |            | no        |
-| MCAD                          | Abhishek Malvankar, Antonin Stefanutti |            | yes       |
-| InstaScale                    | Abhishek Malvankar, Dimitri Saridakis  |            | yes       |
-| CodeFlare Operator            | Anish Asthana, Antonin Stefanutti      |            | yes       |
+| Group              | Key Contacts                           | Date | Impacted? |
+| ------------------ | -------------------------------------- | ---- | --------- |
+| CodeFlare SDK      | Mustafa Eyceoz, Dimitri Saridakis      |      | no        |
+| MCAD               | Abhishek Malvankar, Antonin Stefanutti |      | yes       |
+| InstaScale         | Abhishek Malvankar, Dimitri Saridakis  |      | yes       |
+| CodeFlare Operator | Anish Asthana, Antonin Stefanutti      |      | yes       |
 
 ## Reviews
 


### PR DESCRIPTION
Pass over the current ADRs to update their statuses, using Kubernetes KEP convention.